### PR TITLE
Issue/12 image size

### DIFF
--- a/windshaft/Dockerfile
+++ b/windshaft/Dockerfile
@@ -1,32 +1,31 @@
-FROM ubuntu:xenial-20170802
+FROM ubuntu:xenial-20170802 as builder
 
+# Build env
 # Install required packages
 
-RUN apt-get update && \
-  apt-get install -yq \
-  locales \
-  build-essential \
-  git \
-  curl \
-  libmapnik-dev \
-  pkg-config \
-  python-dev \
-  libcairo2-dev \
-  libjpeg-dev \
-  libpango1.0-dev \
-  libgif-dev \
-  g++
+RUN set -ex; apt-get update && \
+    apt-get install -yq \
+    locales \
+    build-essential \
+    git \
+    curl \
+    libmapnik-dev \
+    pkg-config \
+    python-dev \
+    libcairo2-dev \
+    libjpeg-dev \
+    libpango1.0-dev \
+    libgif-dev \
+    g++ && \
+    locale-gen en_US.UTF-8
 
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    NVM_DIR=/usr/local/nvm \
+    NODE_VERSION=6.11.1
 
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 6.11.1
-
-RUN curl -o- \
+RUN set -e; curl -o- \
     https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh \
     | bash \
     && . $NVM_DIR/nvm.sh \
@@ -34,28 +33,50 @@ RUN curl -o- \
     && nvm alias default $NODE_VERSION \
     && nvm use default
 
-ENV NODE_PATH $NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-RUN node --version
-RUN npm --version
-
-RUN npm install nodemon -g
-
-EXPOSE 4000
-ENV NODE_ENV production
-ENV PGSSLMODE verify-full
-ENV PGSSLROOTCERT /etc/ssl/certs/ca-certificates.crt
-
-#RUN useradd --user-group --create-home --shell /bin/false app
-#ENV HOME=/home/app
-#USER app
-#WORKDIR $HOME/tiler
+ENV NODE_PATH=$NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules \
+    PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 COPY server/package.json server/npm-shrinkwrap.json /tiler/
+
 RUN cd /tiler && npm install
 
-COPY server /tiler
+# Execute environment
+
+FROM ubuntu:xenial-20170802
+
+RUN set -ex; apt-get update && \
+    apt-get install -y --no-install-recommends \
+    locales \
+    libcairo2-dev \
+    libjpeg-dev \
+    libpango1.0-dev \
+    libgif-dev \
+    ca-certificates && \
+    locale-gen en_US.UTF-8 && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    NVM_DIR=/usr/local/nvm \
+    NODE_VERSION=6.11.1 \
+    NODE_ENV=production \
+    PGSSLMODE=verify-full \
+    PGSSLROOTCERT=/etc/ssl/certs/ca-certificates.crt
+
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH \
+    NODE_PATH=$NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules
+
 WORKDIR /tiler
+
+COPY --from=builder $NVM_DIR $NVM_DIR
+
+COPY --from=builder /tiler/node_modules ./node_modules
+
+EXPOSE 4000
+
+COPY server /tiler
+
 RUN chmod u+x ./run.sh
+
 CMD ./run.sh

--- a/windshaft/Dockerfile
+++ b/windshaft/Dockerfile
@@ -38,7 +38,8 @@ ENV NODE_PATH=$NVM_DIR/versions/node/v$NODE_VERSION/lib/node_modules \
 
 COPY server/package.json server/npm-shrinkwrap.json /tiler/
 
-RUN cd /tiler && npm install
+RUN npm install -g nodemon && \
+    cd /tiler && npm install
 
 # Execute environment
 


### PR DESCRIPTION
* We reduce the size of the image by using multi-stage build: `builder` has all the necessary tools and libraries for compiling native code. The latter stage only has a copy of the resulting `node_modules` folder plus our server code
* We limit the number of layers by grouping `ENV` and `RUN` directives as much as possible