### PR TITLE
npm ERR! fetch failed

### DIFF
--- a/windshaft/server/npm-shrinkwrap.json
+++ b/windshaft/server/npm-shrinkwrap.json
@@ -87,7 +87,7 @@
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@0.0.8",
-                      "resolved": "https://npm-registry.whitewater.ibm.com/m/minimist/_attachments/minimist-0.0.8.tgz"
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },


### PR DESCRIPTION
On development, npm logs:

windshaft_1  | npm ERR! fetch failed https://npm-registry.whitewater.ibm.com/m/minimist/_attachments/minimist-0.0.8.tgz
windshaft_1  | npm WARN retry will retry, error on last attempt: Error: getaddrinfo ENOTFOUND npm-registry.whitewater.ibm.com npm-registry.whitewater.ibm.com:443